### PR TITLE
fix: add membersNoUser.UserId to group by

### DIFF
--- a/services/messageService.js
+++ b/services/messageService.js
@@ -155,7 +155,7 @@ const messageService = {
         ) as membersNoUser
         on membersNoUser.RoomId = messages.roomId
         where(messages.roomId like '%n${id}' or messages.roomId like '${id}n%')
-        Group by roomId
+        Group by roomId, membersNoUser.UserId
       ) as temp
       on messages.createdAt = temp.createdAt and messages.roomId = temp.roomId
       left join users on users.id = temp.UserId


### PR DESCRIPTION
## error修復細節
```sql
Select MAX(messages.createdAt) as 'createdAt', messages.roomId, membersNoUser.UserId From messages
inner join(
  select * from members where members.UserId != ${id}
) as membersNoUser
on membersNoUser.RoomId = messages.roomId
where(messages.roomId like '%n${id}' or messages.roomId like '${id}n%')
Group by roomId, membersNoUser.UserId
```

這個程式碼裡面，因為roomId的邏輯我們人類已知只有兩個UserId，而排除掉自己後，membersNoUser.UserId就會是唯一值，但資料庫不知道我們背後有這個邏輯XD我一時間想不到如何通過SQL讓資料庫知道，但既然已經確定值一定是唯一，那把membersNoUser.UserId也一起放進去group by也一樣會是正確值(因為他就是唯一值)。

換個方式說，我們可以確定我們所要的結果roomId和userId會相依(不論單獨是group by roomId或是userId都會有相同結果)，那就可以放入group by內而不會出錯。

這是我思考後的邏輯，應該可行QQ

## 版本造成的error
5.7版本以上之後才會預設full_group_by，主要是為了預防group後有些欄位值並不是唯一而造成的取值錯誤。
需要使用聚合函數或把欄位加到group by去消除錯誤發生。

為什麼ClearDB沒出錯呢?因為他是5.65，就差這麼個臨門一腳XD